### PR TITLE
ci(release): set npm version from git tag at publish time

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,5 +44,11 @@ jobs:
       - name: Clean platform-specific binaries before publish
         run: rm -rf bin/
 
+      - name: Set version from Git tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Setting version to $VERSION"
+          npm version "$VERSION" --no-git-tag-version
+
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --provenance --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falkordblite",
-  "version": "0.2.0",
+  "version": "0.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falkordblite",
-      "version": "0.2.0",
+      "version": "0.0.0-dev",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkordblite",
-  "version": "0.2.0",
+  "version": "0.0.0-dev",
   "description": "Embedded FalkorDB for Node.js/TypeScript — zero-config graph database",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Mirror the release workflow from [falkordb-ts](https://github.com/FalkorDB/falkordb-ts/blob/main/.github/workflows/publish.yml): keep `package.json` pinned at `0.0.0-dev` and have the publish workflow stamp the real version from the GitHub release tag (`GITHUB_REF_NAME`) right before `npm publish`. This avoids hand-bumping `package.json` per release and keeps `main` clean.

## Changes
- `package.json` / `package-lock.json`: set `version` to `0.0.0-dev`.
- `.github/workflows/publish.yml`: add a `Set version from Git tag` step that strips the leading `v` from the tag and runs `npm version --no-git-tag-version`, and switch `npm publish` to `--provenance --access public` (the workflow already has `id-token: write`).

## Testing
- N/A at PR time. The change exercises only at release. To validate end-to-end, cut a test tag/release (e.g. `v0.2.1-test`) on a fork and confirm the published tarball reports the tag version.

## Memory / Performance Impact
N/A — CI/release-only change.

## Related Issues
Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to `0.0.0-dev` in manifest.
  * Enhanced publishing to include provenance and publish as public for greater transparency.
  * Automated package versioning to derive releases from release tag names for streamlined, consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->