### PR TITLE
feat: update FalkorDB to v4.18.3 and Redis to 8.6.2

### DIFF
--- a/.github/workflows/publish-platform-packages.yml
+++ b/.github/workflows/publish-platform-packages.yml
@@ -6,11 +6,11 @@ on:
       redis_version:
         description: 'Redis version to build'
         required: true
-        default: '8.2.3'
+        default: '8.6.2'
       falkordb_version:
         description: 'FalkorDB release tag'
         required: true
-        default: 'v4.16.3'
+        default: 'v4.18.3'
 
 jobs:
   build-and-publish:
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd "packages/${{ matrix.platform }}"
           # Derive version from Redis and FalkorDB versions
-          # Redis 8.2.3 + FalkorDB v4.16.3 -> 8.2.3-falkordb.4.16.3
+          # Redis 8.6.2 + FalkorDB v4.18.3 -> 8.6.2-falkordb.4.18.3
           FALKORDB_VERSION="${{ inputs.falkordb_version }}"
           FALKORDB_VERSION_CLEAN="${FALKORDB_VERSION#v}"
           PACKAGE_VERSION="${{ inputs.redis_version }}-falkordb.${FALKORDB_VERSION_CLEAN}"

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -11,7 +11,7 @@ import { get as httpGet } from 'node:http';
 // ---------------------------------------------------------------------------
 
 /** Default FalkorDB release version to download. */
-export const FALKORDB_VERSION = 'v4.16.3';
+export const FALKORDB_VERSION = 'v4.18.3';
 
 /** Maximum HTTP redirects to follow (GitHub → S3). */
 const MAX_REDIRECTS = 5;
@@ -38,7 +38,7 @@ export interface BinaryManagerOptions {
   falkordbModulePath?: string;
   /** Directory to store downloaded binaries. Defaults to &lt;package-root&gt;/bin. */
   binDir?: string;
-  /** FalkorDB GitHub release tag, e.g. "v4.16.3". */
+  /** FalkorDB GitHub release tag, e.g. "v4.18.3". */
   falkordbVersion?: string;
 }
 


### PR DESCRIPTION
## Summary
Bump the FalkorDB server and Redis versions used by falkordblite.

## Changes
- `src/binary-manager.ts`: `FALKORDB_VERSION` constant `v4.16.3` → `v4.18.3`
- `.github/workflows/publish-platform-packages.yml`: default `redis_version` `8.2.3` → `8.6.2`, default `falkordb_version` `v4.16.3` → `v4.18.3`, updated version comment
- `packages/linux-x64/package.json`: version `8.2.3-falkordb.4.16.3` → `8.6.2-falkordb.4.18.3`
- `packages/darwin-arm64/package.json`: version `8.2.3-falkordb.4.16.2` → `8.6.2-falkordb.4.18.3`

## Testing
CI tests download and run the FalkorDB binary against the `FALKORDB_VERSION` constant. Any integration test run will exercise the new versions.

## Memory / Performance Impact
N/A

## Related Issues
N/A